### PR TITLE
Eliminated uninitiaized vertices in EdgesHelper

### DIFF
--- a/src/extras/helpers/EdgesHelper.js
+++ b/src/extras/helpers/EdgesHelper.js
@@ -91,6 +91,8 @@ THREE.EdgesHelper = function ( object, hex, thresholdAngle ) {
 		}
 
 	}
+    
+    	coords = coords.subarray(0, index);
 
 	geometry.addAttribute( 'position', new THREE.BufferAttribute( coords, 3 ) );
 


### PR DESCRIPTION
When lines of adjacent faces get skipped in EdgesHelper, uninitialized vertices remained in the coordinates buffer.Those become visible as minimal dots at the origin of the objects.
